### PR TITLE
Trim/crop datasets to area of interest

### DIFF
--- a/src/1a_prep_MPA.jl
+++ b/src/1a_prep_MPA.jl
@@ -76,7 +76,6 @@ if !isfile(joinpath(MPA_OUTPUT_DIR, "ports_buffer.gpkg"))
         port_buffer;
         crs=EPSG_7844
     )
-    port_buffer = nothing
 end
 
 
@@ -106,17 +105,74 @@ end
     end
 
     @debug "$(now()) - Processing $(reg) - bathy and slope"
+
     # Process bathymetry and slope UTM raster files
+    # Write to "[some_file].tif.tif" temporarily.
+    # The extra extension is used so the correct format is auto-selected without
+    # needing a separate temporary filename (useful for debugging)
     raw_bathy_fn = first(glob("*.tif", joinpath(MPA_DATA_DIR, "bathy", reg)))
-    process_UTM_raster(raw_bathy_fn, criteria_paths[:Depth], EPSG_7844, -9999.0, reg; method=:bilinear)
+    process_UTM_raster(
+        raw_bathy_fn,
+        criteria_paths[:Depth] * ".tif",
+        EPSG_7844,
+        -9999.0,
+        reg;
+        method=:bilinear
+    )
 
-    raw_slope_fn = first(glob("*.tif", joinpath(MPA_DATA_DIR, "slope", reg)))
-    process_UTM_raster(raw_slope_fn, criteria_paths[:Slope], EPSG_7844, -9999.0, reg; method=:bilinear)
+    target_depth = crop_to_region(
+        criteria_paths[:Depth] * ".tif",
+        EPSG_4326,
+        regions_4326[reg_idx_4326, :geometry],
+        criteria_paths[:Depth]
+    )
 
-    # Process GBR-wide raster data
+    if !isnothing(target_depth)
+        # Write out cropped dataset if needed
+        Rasters.write(criteria_paths[:Depth], target_depth; force=true)
+        target_depth = nothing
+    end
+
     # Load bathymetry data to provide corresponding spatial extent
     bathy_gda2020 = Raster(criteria_paths[:Depth]; crs=EPSG_7844, lazy=true)
 
+    # Delete the temporary copy
+    rm(criteria_paths[:Depth] * ".tif"; force=true)
+
+    # Write to "[some_file].tif.tif" temporarily.
+    # The extra extension is used so the correct format is auto-selected without
+    # needing a separate temporary filename (useful for debugging)
+    raw_slope_fn = first(glob("*.tif", joinpath(MPA_DATA_DIR, "slope", reg)))
+    process_UTM_raster(
+        raw_slope_fn,
+        criteria_paths[:Slope] * ".tif",
+        EPSG_7844,
+        -9999.0,
+        reg;
+        method=:bilinear
+    )
+
+    target_slope = crop_to_region(
+        criteria_paths[:Slope] * ".tif",
+        EPSG_4326,
+        regions_4326[reg_idx_4326, :geometry],
+        criteria_paths[:Slope]
+    )
+
+    # Resample to align with depth dataset
+    resample_and_write(
+        target_slope,
+        bathy_gda2020,
+        criteria_paths[:Slope];
+        method=:bilinear
+    )
+
+    # Delete the temporary copy
+    rm(criteria_paths[:Slope] * ".tif"; force=true)
+
+    target_slope = nothing
+
+    # Process other raster data for region
     @debug "$(now()) - Processing $(reg) - Benthic"
     raw_benthic_fn = "$(MPA_DATA_DIR)/benthic/GBR10 GBRMP Benthic.tif"
     target_benthic = crop_to_region(
@@ -183,7 +239,12 @@ end
     # Process wave raster data
     # Use bathy dataset as a template for writing netCDF data to geotiff
     src_bathy_path = first(glob("*.tif", joinpath(MPA_DATA_DIR, "bathy", reg)))
-    rst_template = Raster(src_bathy_path, crs=REGION_CRS_UTM[reg], mappedcrs=EPSG(4326))
+    rst_template = Raster(
+        src_bathy_path;
+        crs=REGION_CRS_UTM[reg],
+        mappedcrs=EPSG(4326),
+        lazy=true
+    )
 
     @debug "$(now()) - Processing $(reg) - Waves Hs"
     waves_Hs_path = first(glob("*.nc", joinpath(WAVE_DATA_DIR, "Hs", reg)))
@@ -210,14 +271,12 @@ end
     )
 
     # Calculate distance to nearest port
-    port_buffer = GDF.read(joinpath(MPA_OUTPUT_DIR, "port_buffer.gpkg"))
     port_points = GDF.read(joinpath(MPA_OUTPUT_DIR, "ports_GDA2020.gpkg"))
 
     @debug "$(now()) - Processing $(reg) - Ports"
     within_port_range(
         criteria_paths[:Depth],
         port_buffer,
-        -9999.0,
         criteria_paths[:PortDistSlopes],
     )
 
@@ -232,8 +291,12 @@ end
         MPA_BENTHIC_IDS,
         MPA_SLOPE_IDS,
         7, (3, 3), 70, (9, 9),
-        valid_slopes_fn,
-        reg
+        valid_slopes_fn
+    )
+
+    resize_to_valid_area(
+        criteria_paths,
+        valid_slopes_fn
     )
 
     # Create lookup tables to support fast querying

--- a/src/1a_prep_MPA.jl
+++ b/src/1a_prep_MPA.jl
@@ -1,6 +1,9 @@
 """
 Prepare data for analysis by processing MPA files for each GBRMPA management region.
 
+"MPA" is the internal designation. This dataset is commonly known as the UQ-GBRMPA or
+EoMap dataset.
+
 Crop GBR-wide GBRMPA rasters into management regions.
 Reproject all data from WGS84 / UTM Zone 54 - 56 into consistent CRS (GDA2020).
 Ensure all rasters are the same size/shape for each region of interest with the same

--- a/src/1b_prep_ACA.jl
+++ b/src/1b_prep_ACA.jl
@@ -36,7 +36,7 @@ target_benthic_poly = benthic_poly[target_benthic_features, :]
 
         target_flats_reg.geometry = AG.reproject(target_flats_reg.geometry, crs(region_4326_geom), EPSG_7844; order=:trad)
 
-        GDF.write(joinpath(ACA_OUTPUT_DIR, "aca_target_flats_$(reg).gpkg"), target_flats_reg; crs=EPSG(7844))
+        GDF.write(joinpath(ACA_OUTPUT_DIR, "aca_target_flats_$(reg).gpkg"), target_flats_reg; crs=EPSG_7844)
     end
 
     if !isfile(joinpath(ACA_OUTPUT_DIR, "aca_target_slopes_$(reg).gpkg"))
@@ -45,7 +45,7 @@ target_benthic_poly = benthic_poly[target_benthic_features, :]
 
         target_slopes_reg.geometry = AG.reproject(target_slopes_reg.geometry, crs(region_4326_geom), EPSG_7844; order=:trad)
 
-        GDF.write(joinpath(ACA_OUTPUT_DIR, "aca_target_slopes_$(reg).gpkg"), target_slopes_reg; crs=EPSG(7844))
+        GDF.write(joinpath(ACA_OUTPUT_DIR, "aca_target_slopes_$(reg).gpkg"), target_slopes_reg; crs=EPSG_7844)
     end
 
     if !isfile(joinpath(ACA_OUTPUT_DIR, "aca_benthic_$(reg).gpkg"))
@@ -54,7 +54,7 @@ target_benthic_poly = benthic_poly[target_benthic_features, :]
 
         benthic_reg.geometry = AG.reproject(benthic_reg.geometry, crs(region_4326_geom), EPSG_7844; order=:trad)
 
-        GDF.write(joinpath(ACA_OUTPUT_DIR, "aca_benthic_$(reg).gpkg"), benthic_reg; crs=EPSG(7844))
+        GDF.write(joinpath(ACA_OUTPUT_DIR, "aca_benthic_$(reg).gpkg"), benthic_reg; crs=EPSG_7844)
     end
 end
 
@@ -63,10 +63,10 @@ end
 
 # Loading GBR-wide data
 aca_bathy_path = "$(ACA_DATA_DIR)/Bathymetry---composite-depth/bathymetry_0.tif"
-aca_bathy = Raster(aca_bathy_path, mappedcrs=EPSG(4326), lazy=true)
+aca_bathy = Raster(aca_bathy_path, mappedcrs=EPSG_4326, lazy=true)
 
 aca_turbid_path = "$(ACA_DATA_DIR)/Turbidity-Q3-2023/turbidity-quarterly_0.tif"
-aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG(4326), lazy=true)
+aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG_4326, lazy=true)
 
 # If a file already exists it is skipped
 @showprogress dt = 10 "Prepping bathymetry/turbidity/wave data..." for reg in REGIONS
@@ -75,9 +75,12 @@ aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG(4326), lazy=true)
     if !isfile(joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif"))
         target_bathy = Rasters.crop(aca_bathy; to=regions_4326[reg_idx_4326, :])
         target_bathy = Rasters.trim(mask(target_bathy; with=regions_4326[reg_idx_4326, :]))
-        target_bathy = Rasters.resample(target_bathy; crs=EPSG_7844)
-
-        write(joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif"), target_bathy; force=true)
+        Rasters.resample(
+            target_bathy;
+            crs=EPSG_7844,
+            filename=joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif"),
+            method=:bilinear
+        )
 
         target_bathy = nothing
         GC.gc()
@@ -85,13 +88,16 @@ aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG(4326), lazy=true)
 
     if !isfile(joinpath(ACA_OUTPUT_DIR, "$(reg)_turbid.tif"))
         bathy_gda2020_path = joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif")
-        bathy_gda2020 = Raster(bathy_gda2020_path; crs=EPSG(7844), lazy=true)
+        bathy_gda2020 = Raster(bathy_gda2020_path; crs=EPSG_7844, lazy=true)
 
         target_turbid = Rasters.crop(aca_turbid; to=regions_4326[reg_idx_4326, :])
         target_turbid = Rasters.trim(mask(target_turbid; with=regions_4326[reg_idx_4326, :]))
-        target_turbid = resample(target_turbid; to=bathy_gda2020)
-
-        write(joinpath(ACA_OUTPUT_DIR, "$(reg)_turbid.tif"), target_turbid; force=true)
+        Rasters.resample(
+            target_turbid;
+            to=bathy_gda2020,
+            filename=joinpath(ACA_OUTPUT_DIR, "$(reg)_turbid.tif"),
+            method=:bilinear
+        )
 
         target_turbid = nothing
         bathy_gda2020 = nothing
@@ -100,10 +106,10 @@ aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG(4326), lazy=true)
 
     if !isfile(joinpath(ACA_OUTPUT_DIR, "$(reg)_waves_Hs.tif"))
         mpa_bathy_path = first(glob("*.tif", joinpath(MPA_DATA_DIR, "bathy", reg)))
-        mpa_bathy = Raster(mpa_bathy_path, mappedcrs=EPSG(4326), lazy=true)
+        mpa_bathy = Raster(mpa_bathy_path, mappedcrs=EPSG_4326, lazy=true)
 
         target_waves_Hs_path = first(glob("*.nc", joinpath(WAVE_DATA_DIR, "Hs", reg)))
-        target_waves_Hs = Raster(target_waves_Hs_path, key=:Hs90, crs=crs(mpa_bathy), mappedcrs=EPSG(4326), lazy=true)
+        target_waves_Hs = Raster(target_waves_Hs_path, key=:Hs90, crs=crs(mpa_bathy), mappedcrs=EPSG_4326, lazy=true)
 
         # Extend bounds of wave data to match bathymetry if needed
         if size(mpa_bathy) !== size(target_waves_Hs)
@@ -120,17 +126,18 @@ aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG(4326), lazy=true)
         target_waves_Hs = tmp_Hs
 
         # Set to known missing value
-        target_waves_Hs.data[target_waves_Hs.data .< -9999.0] .= -9999.0
+        target_waves_Hs.data[target_waves_Hs.data.<-9999.0] .= -9999.0
         replace_missing!(target_waves_Hs, -9999.0)
 
         # Reproject raster to GDA 2020
-        target_waves_Hs = Rasters.resample(target_waves_Hs; crs=EPSG_7844)
-
         # Have to resample to aca_bathy to ensure extent and resolution is consistent
-        aca_bathy = Raster(joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif"); crs=EPSG(7844), lazy=true)
-        target_waves_Hs = Rasters.resample(target_waves_Hs; to=aca_bathy)
-
-        write(joinpath(ACA_OUTPUT_DIR, "$(reg)_waves_Hs.tif"), target_waves_Hs; force=true)
+        aca_bathy = Raster(joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif"); crs=EPSG_7844, lazy=true)
+        Rasters.resample(
+            target_waves_Hs;
+            to=aca_bathy,
+            filename=joinpath(ACA_OUTPUT_DIR, "$(reg)_waves_Hs.tif"),
+            method=:bilinear
+        )
 
         mpa_bathy = nothing
         aca_bathy = nothing
@@ -140,10 +147,10 @@ aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG(4326), lazy=true)
 
     if !isfile(joinpath(ACA_OUTPUT_DIR, "$(reg)_waves_Tp.tif"))
         mpa_bathy_path = first(glob("*.tif", joinpath(MPA_DATA_DIR, "bathy", reg)))
-        mpa_bathy = Raster(mpa_bathy_path, mappedcrs=EPSG(4326), lazy=true)
+        mpa_bathy = Raster(mpa_bathy_path, mappedcrs=EPSG_4326, lazy=true)
 
         target_waves_Tp_path = first(glob("*.nc", joinpath(WAVE_DATA_DIR, "Tp", reg)))
-        target_waves_Tp = Raster(target_waves_Tp_path, key=:Tp90, crs=crs(mpa_bathy), mappedcrs=EPSG(4326), lazy=true)
+        target_waves_Tp = Raster(target_waves_Tp_path, key=:Tp90, crs=crs(mpa_bathy), mappedcrs=EPSG_4326, lazy=true)
 
         # Extend bounds of wave data to match bathymetry if needed
         if size(mpa_bathy) !== size(target_waves_Tp)
@@ -160,17 +167,17 @@ aca_turbid = Raster(aca_turbid_path, mappedcrs=EPSG(4326), lazy=true)
         target_waves_Tp = tmp_Tp
 
         # Set to known missing value
-        target_waves_Tp.data[target_waves_Tp.data .< -9999.0] .= -9999.0
+        target_waves_Tp.data[target_waves_Tp.data.<-9999.0] .= -9999.0
         replace_missing!(target_waves_Tp, -9999.0)
 
-        # Reproject raster to GDA 2020
-        target_waves_Tp = Rasters.resample(target_waves_Tp; crs=EPSG_7844)
-
         # Have to resample to aca_bathy to ensure extent and resolution is consistent
-        aca_bathy = Raster(joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif"); crs=EPSG(7844), lazy=true)
-        target_waves_Tp = Rasters.resample(target_waves_Tp; to=aca_bathy)
-
-        write(joinpath(ACA_OUTPUT_DIR, "$(reg)_waves_Tp.tif"), target_waves_Tp; force=true)
+        aca_bathy = Raster(joinpath(ACA_OUTPUT_DIR, "$(reg)_bathy.tif"); crs=EPSG_7844, lazy=true)
+        Rasters.resample(
+            target_waves_Tp;
+            to=aca_bathy,
+            filename=joinpath(ACA_OUTPUT_DIR, "$(reg)_waves_Tp.tif"),
+            method=:bilinear
+        )
 
         mpa_bathy = nothing
         aca_bathy = nothing

--- a/src/geom_handlers/lookup_processing.jl
+++ b/src/geom_handlers/lookup_processing.jl
@@ -98,7 +98,7 @@ Create a lookup table of valid data pixels for fast querying of data layers.
 function valid_lookup(raster_files::NamedTuple, valid_areas_file::String, dst_file::String)::Nothing
     if isfile(dst_file)
         @warn "Data not processed as $(dst_file) already exists."
-        return
+        return nothing
     end
 
     # Create stack of prepared data

--- a/src/geom_handlers/raster_processing.jl
+++ b/src/geom_handlers/raster_processing.jl
@@ -170,7 +170,6 @@ Writes to `dst_file` as a Cloud Optimized Geotiff.
 - `target_missingval` : Consistent missingval to use in output raster.
 - `reg` : Region name for input CRS definition.
 - `method` : Resampling interpolation method (more information https://rafaqz.github.io/Rasters.jl/stable/api#Rasters.resample-Tuple).
-
 """
 function process_UTM_raster(
     src_file::String,
@@ -182,7 +181,7 @@ function process_UTM_raster(
 )::Nothing
     if isfile(dst_file)
         @warn "Data not processed as $(dst_file) already exists."
-        return
+        return nothing
     end
 
     input_raster = Raster(src_file; crs=REGION_CRS_UTM[reg], mappedcrs=EPSG_4326)

--- a/src/geom_handlers/raster_processing.jl
+++ b/src/geom_handlers/raster_processing.jl
@@ -185,9 +185,21 @@ function process_UTM_raster(
     end
 
     input_raster = Raster(src_file; crs=REGION_CRS_UTM[reg], mappedcrs=EPSG_4326)
-    input_raster = set_consistent_missingval!(input_raster, target_missingval)
+    input_raster = set_consistent_missingval!(Rasters.trim(input_raster), target_missingval)
 
-    resample(input_raster; crs=target_crs, filename=dst_file, format="COG", method=method)
+    try
+        # Using `filename` argument reduces memory use but the resulting file is
+        # orders of magnitude bigger, so write out manually
+        input_raster = resample(input_raster; crs=target_crs, method=method)
+        Rasters.write(dst_file, input_raster)
+    catch
+        # In cases where data is too big to fit into memory, attempt to resample
+        # writing out to disk. This results in a larger than usual file but better
+        # than crashing out.
+        resample(input_raster; crs=target_crs, method=method, filename=dst_file)
+    end
+
+    input_raster = nothing
     force_gc_cleanup(; wait_time=2)
 
     return nothing
@@ -223,9 +235,20 @@ function crop_to_region(
         return nothing
     end
 
-    input_raster = Raster(src_file; mappedcrs=input_crs, lazy=true)
+    input_raster = try
+        Raster(src_file; mappedcrs=input_crs)
+    catch
+        Raster(src_file; mappedcrs=input_crs, lazy=true)
+    end
 
-    return crop(input_raster; to=target_region_geom)
+    # Note: trim/mask is very important - otherwise file sizes are GBs!
+    return read(
+        Rasters.trim(
+            Rasters.mask(
+                crop(input_raster; to=target_region_geom); with=target_region_geom
+            )
+        )
+    )
 end
 
 """
@@ -243,7 +266,7 @@ Writes to `dst_file` as a Cloud Optimized Geotiff.
 # Arguments
 - `input_raster` : Input raster dataset for resampling to template_raster.
 - `rst_template` : Template raster for resampling.
-- `dst_file` : File location name to create output file. Should include variable and region information.
+- `dst_file` : File location to check - if exists, this function does nothing.
 - `method` : Resampling interpolation method supported by Rasters.jl, defaulting to `:near` (nearest neighbor)
              (See [Rasters.jl documentation](https://rafaqz.github.io/Rasters.jl/stable/api#Rasters.resample-Tuple)).
 """
@@ -258,7 +281,10 @@ function resample_and_write(
         return nothing
     end
 
-    resample(input_raster; to=rst_template, filename=dst_file, format="COG", method=method)
+    # Using `filename` argument reduces memory use but the resulting file is
+    # orders of magnitude bigger, so write out manually
+    input_raster = resample(input_raster; to=rst_template, method=method)
+    Rasters.write(dst_file, input_raster)
 
     return nothing
 end
@@ -274,8 +300,7 @@ end
         method::Symbol
     )::Nothing
 
-Process wave data from one CRS/PCS to another, writing the results out to disk in COG
-format.
+Process wave data from one CRS/PCS to another, writing the results out to disk as geotiff.
 
 The wave data this function is intended for is provided in netCDF format. The spatial
 extents/coordinates provided in this dataset are not well-read by GDAL. To work around this
@@ -358,7 +383,10 @@ function process_wave_data(
     force_gc_cleanup()
 
     # Reproject raster to GDA2020 (degree projection)
-    resample(target_waves; to=target_rst, filename=dst_file, format="COG", method=method)
+    # Using `filename` argument reduces memory use but the resulting file is
+    # orders of magnitude bigger, so write out manually
+    target_waves = resample(target_waves; to=target_rst, method=method)
+    Rasters.write(dst_file, target_waves)
     force_gc_cleanup(; wait_time=2)
 
     return nothing
@@ -404,7 +432,7 @@ function distance_raster(
     target_raster = calc_distances(target_raster, distance_points; units=units)
 
     target_raster = set_consistent_missingval!(target_raster, target_missingval)
-    write(dst_file, target_raster)
+    Rasters.write(dst_file, target_raster)
     target_raster = nothing
     force_gc_cleanup()
 
@@ -427,7 +455,6 @@ step.
 function within_port_range(
     src_file::String,
     dist_buffer::DataFrame,
-    target_missingval::Union{Int64,Float64},
     dst_file::String
 )::Nothing
     if isfile(dst_file)
@@ -436,9 +463,8 @@ function within_port_range(
     end
 
     target_raster = Raster(src_file; crs=EPSG_7844)
-    target_raster = mask(target_raster; with=dist_buffer, missingval=target_missingval)
-    target_raster[target_raster.>0] .= 1.0
-    write(dst_file, target_raster)
+    target_raster = boolmask(mask(target_raster; with=dist_buffer); missingval=0)
+    Rasters.write(dst_file, UInt8.(target_raster))
 
     target_raster = nothing
     force_gc_cleanup()
@@ -484,8 +510,7 @@ function write_valid_locs(
     first_window::Tuple{Int64,Int64},
     second_min_size::Int64,
     second_window::Tuple{Int64,Int64},
-    dst_file::String,
-    reg::String
+    dst_file::String
 )::Nothing
     if isfile(dst_file)
         @warn "Data not processed as $(dst_file) already exists."
@@ -511,14 +536,31 @@ function write_valid_locs(
     valid_areas.data .= cleaned_areas
     valid_areas = convert.(UInt8, Rasters.trim(valid_areas))
 
-    write(dst_file, valid_areas)
+    Rasters.write(dst_file, valid_areas)
 
     cleaned_areas = nothing
     force_gc_cleanup(; wait_time=2)
 
-    # Replace datasets with data so it covers only the relevant valid areas
+    return nothing
+end
+
+"""
+    resize_to_valid_area(criteria_paths::NamedTuple, valid_fn::String)
+
+Resize processed data files to the area that has data across all criteria layers.
+Replaces existing file.
+
+# Arguments
+- `criteria_paths` : Named collection of criteria paths
+- `valid_fn` : Path/name to valid dataset
+"""
+function resize_to_valid_area(criteria_paths::NamedTuple, valid_fn::String)
+    crits = keys(criteria_paths)
+    valid_areas = Raster(valid_fn; lazy=true)
+
+    # Replace files with copies that only cover the relevant valid areas
     for crit in crits
-        crit_area = Raster(criteria_paths[crit])
+        crit_area = Raster(criteria_paths[crit]; lazy=true)
 
         if crit ∈ [:Benthic, :Geomorphic]
             m = :near
@@ -526,9 +568,19 @@ function write_valid_locs(
             m = :bilinear
         end
 
-        src_data = resample(crop(crit_area; to=valid_areas); to=valid_areas, method=m)
-        @assert size(src_data) == size(valid_areas) "Mismatch between valid area and data area"
-        write(criteria_paths[crit], src_data; force=true)
+        if size(crit_area) == size(valid_areas)
+            @debug "Skipping resizing of $crit ..."
+            continue
+        end
+
+        # Using `filename` argument reduces memory use but the resulting file is
+        # orders of magnitude bigger, so write out manually
+        crit_area = resample(
+            read(Rasters.trim(crit_area));
+            to=valid_areas,
+            method=m
+        )
+        Rasters.write(criteria_paths[crit], crit_area; force=true)
     end
 
     return nothing


### PR DESCRIPTION
Data is taking a lot of memory in production, and one reason is the inclusion of unnecessary "empty" areas (areas where there is no valid data) which could be omitted.

Also changed how data is being written to minimize file sizes as much as possible.